### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](http://media.charlesleifer.com/blog/photos/scout-logo.png)
 
-[scout](http://scout.readthedocs.org/en/latest/) is a RESTful search server written in Python. The search is powered by [SQLite's full-text search extension](http://sqlite.org/fts3.html), and the web application utilizes the [Flask](http://flask.pocoo.org) framework.
+[scout](https://scout.readthedocs.io/en/latest/) is a RESTful search server written in Python. The search is powered by [SQLite's full-text search extension](http://sqlite.org/fts3.html), and the web application utilizes the [Flask](http://flask.pocoo.org) framework.
 
 Features:
 
@@ -13,7 +13,7 @@ Features:
 * Besides full-text search, perform complex filtering based on metadata values.
 * Comprehensive unit-tests.
 * Supports SQLite [FTS4](http://sqlite.org/fts3.html) and the brand-new [FTS5](http://sqlite.org/fts5.html).
-* [Documentation hosted on ReadTheDocs](http://scout.readthedocs.org/en/latest/).
+* [Documentation hosted on ReadTheDocs](https://scout.readthedocs.io/en/latest/).
 
 ## Installation
 
@@ -41,4 +41,4 @@ $ python setup.py install
 
 Using either of the above methods will also ensure the project's Python dependencies are installed: [flask](http://flask.pocoo.org) and [peewee](http://docs.peewee-orm.com).
 
-[Check out the documentation](http://scout.readthedocs.org/en/latest/) for more information about the project.
+[Check out the documentation](https://scout.readthedocs.io/en/latest/) for more information about the project.

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -9,7 +9,7 @@ Scout provides a WSGI app, so you can use any WSGI server for deployment. Popula
 
 * `Gevent <http://www.gevent.org/>`_
 * `Gunicorn <http://gunicorn.org/>`_
-* `uWSGI <https://uwsgi-docs.readthedocs.org/en/latest/>`_
+* `uWSGI <https://uwsgi-docs.readthedocs.io/en/latest/>`_
 
 The Flask documentation also provides a list of popular WSGI servers and how to integrate them with Flask apps. Since Scout is a Flask application, all of these examples should work with minimal modification:
 
@@ -70,4 +70,4 @@ Here is how you might run using the above wrapper script:
 
     $ uwsgi --http :8000 --wsgi-file wrapper.py --master --processes 4 --threads 2
 
-It is common to run uWSGI behind Nginx. For more information `check out the uWSGI docs <http://uwsgi-docs.readthedocs.org/en/latest/WSGIquickstart.html>`_.
+It is common to run uWSGI behind Nginx. For more information `check out the uWSGI docs <https://uwsgi-docs.readthedocs.io/en/latest/WSGIquickstart.html>`_.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
