### PR TITLE
No wrapper required to run scout on gunicorn.

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -39,15 +39,7 @@ You could then run the wrapper script using a tool like `supervisord <http://sup
 Gunicorn
 --------
 
-Here is an example wrapper script for running Scout using Gunicorn.
-
-.. code-block:: python
-
-    # Wrapper script to initialize database.
-    from scout.server import parse_options
-    app = parse_options()
-
-Here is how to run gunicorn using the above wrapper script:
+Here is an example for running Scout using Gunicorn.
 
 .. code-block:: console
 

--- a/scout/server.py
+++ b/scout/server.py
@@ -208,9 +208,9 @@ def parse_options():
     return create_server(config, config_file)
 
 
+application = parse_options()
 def main():
-    app = parse_options()
-    run(app)
+    run(application)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
*Modified server.py:
  -Gunicorn can run scout without wrapper.py
*Updated deployment.rst|
  -Updated document, according to changes made in server.py.