### PR TITLE
Rework Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,30 @@
-FROM alpine:3.7
+FROM ghcr.io/astral-sh/uv:0.7 AS uv-base
+
+FROM alpine:3.21
 ENV SCOUT_DATABASE=/data/search-index.db
 COPY ./server /srv/
 
 # Install Python deps and ensure peewee C extensions are compiled.
-RUN apk add --no-cache --virtual .build-deps build-base python3-dev \
-      && apk add --no-cache libev python3 py3-pip sqlite-dev sqlite libffi-dev \
-      && pip3 install --no-cache-dir cython \
-      && pip3 install --no-cache-dir gevent scout \
-      && apk del .build-deps
+RUN \
+    --mount=type=bind,from=uv-base,source=/uv,target=/usr/local/bin/uv \
+    apk add --no-cache \
+        libev python3 sqlite \
+    && \
+    apk add --no-cache \
+        --virtual .build-deps \
+        build-base libev-dev python3-dev sqlite-dev \
+    && \
+    UV_BREAK_SYSTEM_PACKAGES=1 \
+    UV_COMPILE_BYTECODE=1 UV_LINK_MODE='copy' \
+    UV_NO_CACHE=1 UV_NO_CONFIG=1 UV_NO_MANAGED_PYTHON=1 \
+    UV_NO_PROGRESS=1 UV_SYSTEM_PYTHON=1 \
+    uv pip install --strict \
+        cython gevent scout \
+    && \
+    apk del --no-cache --purge .build-deps
+    
 EXPOSE 9004
 VOLUME /data/
 
 WORKDIR /data
-ENTRYPOINT ["python3", "/srv/server.py", "-H", "0.0.0.0", "-p", "9004", "-s", "porter", "-l", "/data/scout.log"]
+ENTRYPOINT ["/usr/bin/env", "python3", "/srv/server.py", "-H", "0.0.0.0", "-p", "9004", "-s", "porter", "-l", "/data/scout.log"]


### PR DESCRIPTION
The `Dockerfile` was using very out-of-date versions.

Possible further improvements:
* Use a Python docker image instead of `alpine`
* Keep the first installed package set in a layer

Changes:

- Upgrade to the current stable `alpine` tag
- Install the packages to keep first
- Use `uv pip install`